### PR TITLE
Update eip-7870.md

### DIFF
--- a/EIPS/eip-7870.md
+++ b/EIPS/eip-7870.md
@@ -2,7 +2,7 @@
 eip: 7870
 title: Hardware and Bandwidth Recommendations for Validators and Full Nodes
 description: System recommendations for Validators and Full nodes
-author: Parithosh Jayanthi (@parithosh), Kevaundray Wedderburn (@kevaundray), Josh Rudolf (@jrudolf), Dankrad Feist (@dankrad), Justin Traglia (@jtraglia), Ignacio Hagopian (@jsign), George Kadianakis (@asn-d6)
+author: Parithosh Jayanthi (@parithosh), Kevaundray Wedderburn (@kevaundray), Josh Rudolf (@jrudolf), Dankrad Feist (@dankrad), Justin Traglia (@jtraglia), Ignacio Hagopian (@jsign), George Kadianakis (@asn-d6), Fredrik Svantes (@fredriksvantes)
 discussions-to: https://ethereum-magicians.org/t/hardware-and-bandwidth-recommendations-for-full-nodes-and-validators/22675
 status: Draft
 type: Informational
@@ -11,99 +11,127 @@ created: 2025-01-26
 
 ## Abstract
 
-This proposal specifies hardware and bandwidth recommendations for full nodes and validators. Validators are split into attesters and proposers. The resource-intensive aspect of block proposal lies in creating the block and broadcasting the data required for attesters to validate it. We use the term "local block builder" to further emphasize this separation.
+This proposal specifies hardware and bandwidth recommendations for different types of Ethereum nodes:
 
-We note that you may be able to run a client with less than the recommended specifications, however benchmarks and decision-making will be made with respect to these recommendations.
+- **Full nodes**: Nodes that follow the tip of the chain without necessarily proposing blocks.
+- **Validators**: Split into:
+  - **Attesters**: Validators that validate and attest to blocks created by proposers.
+  - **Local block builders** (Proposers): Validators that create blocks locally and broadcast them to the network.
+
+The resource-intensive aspect for local block builders lies in creating the block and quickly broadcasting the data required for attesters to validate it in time.
+
+We note that it may be possible to run a client with less than the recommended specifications, however benchmarks and decision-making will be made with respect to these recommendations.
 
 ## Motivation
 
 Clear system specifications are crucial for:
 
-- Ensuring meaningful benchmark comparisons across different implementations
-- Enabling informed decision-making about protocol upgrades and their resource usage implications
-- Providing clear guidance for node operators with respect to the future
+- Ensuring meaningful benchmark comparisons across different client implementations.
+- Enabling informed decision-making about protocol upgrades and their resource usage implications.
+- Providing clear guidance for node operators to ensure alignment with future network requirements.
 
 Without a shared understanding of target hardware specifications:
 
-- Benchmark results lose significance due to inconsistent testing environments
-- Decision-making becomes challenging for implementation choices, as performance characteristics are heavily hardware-dependent
-- Network participants lack clear guidance for hardware investments
+- Benchmark results lose significance due to inconsistent testing environments.
+- Decision-making becomes challenging for implementation choices, as performance characteristics are heavily hardware-dependent.
+- Network participants lack clear guidance for hardware investments.
 
 ## Specification
 
-### Recommended hardware and bandwidth specifications
+### Roles and Their Recommended Specifications
 
-| Node type           | Storage | RAM  | CPU cores          | CPU Single Thread/Multithread rating | Download/Upload speed |
-| ------------------- | ------- | ---- | ------------------ | ------------------------------------ | --------------------- |
-| Full node           | 4TB     | 32GB | 4 cores/8 threads  | 1000 / 3000                          | 50 Mbps / 15 Mbps     |
-| Attester            | 4TB     | 64GB | 8 cores/16 threads | 3500 / 25000                         | 50 Mbps / 25 Mbps     |
-| Local block builder | 4TB     | 64GB | 8 cores/16 threads | 3500 / 25000                         | 100 Mbps / 50 Mbps    |
+Node operators typically run both an **Execution Layer (EL)** client and a **Consensus Layer (CL)** client on the same machine. The specifications below assume the combined resource usage of both.
 
-- The CPU rating is a measure of how powerful a particular CPU is for single and multithreaded respectively. All numbers referenced are normalized according to PassMark.
+| Node Type               | Storage       | RAM   | CPU Cores / Threads | **PassMark CPU Rating**                            | Download / Upload speed  |
+|-------------------------|---------------|-------|---------------------|----------------------------------------------------|--------------------------|
+| **Full Node**           | 4 TB NVMe     | 32 GB | 4c / 8t             | ~1000 ST / 3000 MT                                 | 50 Mbps / 15 Mbps        |
+| **Attester**            | 4 TB NVMe     | 64 GB | 8c / 16t            | ~3500 ST / 25000 MT                                | 50 Mbps / 25 Mbps        |
+| **Local Block Builder** | 4 TB NVMe     | 64 GB | 8c / 16t            | ~3500 ST / 25000 MT                                | 100 Mbps / 50 Mbps       |
+
+*Approximate single-thread (ST) and multi-thread (MT) PassMark CPU scores. For example, a PassMark ST rating of 3500 and an MT rating of 25000 typically corresponds to upper mid-range server CPUs circa 2024–2025.*
 
 ## Rationale
 
 ### Storage
 
-For storage, we recommend an SSD with the following metrics:
-
-- Sequential Reads: 7,000 MB/s
-- Sequential Writes: 7,000 MB/s
-- Random 4K Reads: Up to 1,000,000 IOPS
-- Random 4K Writes: Up to 1,000,000 IOPS
-
-In particular, we recommend purchasing NVMe M.2 with DRAM cache and TLC flash for storage instead of SATA as NVMe has higher throughput. NVMe drives that are DRAMless or use QLC flash are not advised.
-
-As of January 2025, the storage requirements for all node types are dominated by the need to store block history.
-A 2TB disk can be used; however, this is not recommended due to the rate of history growth and the uncertainty as to when EIP-4444 will be completed.
+- **Recommended**: 4 TB NVMe M.2 drive with:
+  - **Sequential R/W**: 7,000 MB/s
+  - **Random 4K R/W**: Up to 1,000,000 IOPS
+- **Why NVMe over SATA?**
+  - NVMe drives have significantly higher throughput and lower latency than SATA SSDs.  
+  - Drives without DRAM (DRAMless) or with QLC flash are not advised, due to lower endurance and potentially lower sustained performance.
+- **On Endurance (TBW)**  
+  - Running a node involves frequent writes (e.g., database updates, logs). Ensure that the SSD’s Total Bytes Written (TBW) rating is sufficient for multi-year operation.
+- **Capacity Considerations**  
+  - As of January 2025, 2 TB can still work, but daily chain growth makes 4 TB more future-proof.  
+  - While EIP-4444 aims to reduce historical storage requirements, the timeline for EIP-4444 remains uncertain.
 
 ### Memory
 
-Memory (RAM) is dominated by state cache. As of January 2025, it is possible to run a full node with 16GB of RAM, however this has been known to not work with all combinations of EL and CL clients in the past.
+- **Why 64 GB for Validators (Attester / Local Block Builder)?**
+  - Running an Ethereum validator (both EL & CL clients) can be memory-intensive, with state cache dominating RAM usage.
+  - Certain memory intensive client combinations have historically failed with 16 GB.  
+  - Preliminary benchmarks (e.g., [zk-STARK memory usage](https://hackmd.io/@han/bench-hash-in-snark)) suggest cryptographic operations can demand significant RAM.  
+  - Relative to total hardware costs, upgrading from 32 GB to 64 GB is a small price but can improve stability and is more future proof with regards to zk-STARKS.
 
-On 32GB vs 64GB; 32GB works right now, however we recommend 64GB as [preliminary benchmarks](https://hackmd.io/@han/bench-hash-in-snark) have shown that zk-STARKS can consume a significant amount of memory and the difference in cost relative to the entire hardware setup for a validator is insignificant.
+### CPU
+
+- **Single vs. Multi-thread Performance**
+  - Attesters and local block builders benefit from both high single-thread performance and solid multi-thread performance.  
 
 ### Bandwidth
 
-- Statista states that as of January 2024:
-  - The global average download for broadband is 92 Mbps and the global average upload is 43 Mbps.
-  - The global average download for mobile is 50 Mbps and 11 Mbps.
-- GSMA report showing the state of mobile internet connectivity in 2024 shows that:
-  - The mobile upload speeds in Higher Income Countries (HIC) is about 18 Mbps.
-  - The global average mobile download is 48 Mbps.
+#### Local Block Builders
 
-Although most users will be using fixed broadband as opposed to mobile broadband. We include the mobile broadband figures as a way to approximate lower bounds.
-
-#### Local block builders
-
-For validators that want to build blocks locally, we recommend global bandwidth figures inline with the global average for fixed broadband: 100 Mbps download and 50 Mbps upload.
-
-*If a block builder does not have the recommended bandwidth, we recommend that they build a block that is partially full and or one that includes fewer blobs.*
+- **Recommended**: 100 Mbps download, 50 Mbps upload.
+- **Rationale**:  
+  - Distributing blocks is highly bandwidth-intensive.  
+  - If a builder cannot meet these speeds, they risk slower propagation and causing late blocks.  
+  - In extreme cases, a low-bandwidth node could propose partially full blocks or one that includes fewer blobs to mitigate slow broadcast.
 
 #### Attesters
 
-For attesters, we recommend 50 Mbps download and 25 Mbps upload.
+- **Recommended**: 50 Mbps download, 25 Mbps upload.
+- **Minimum tested**: 15 Mbps (as per [ethPandaOps](https://ethpandaops.io/) simulations where 40% of the network had Gigabit connections and the other 60% had 15 Mbps upload).
+  - However, real-world performance depends on peer network topology. A node with poor bandwidth could in theory quickly share data with a well-connected peer with good bandwidth which means that this peer could quickly seed the network.
+- **Rationale**:
+  - 25 Mbps was chosen as a buffer to account for these miscellaneous factors that are harder to predict.
 
-The minimum value recorded to work as of January 2025 has been ~15 Mbps. This was recorded in simulations done by ethPandaOps where 40% of the network had Gigabit connections and the other 60% had 15 Mbps upload.
+#### Validators Using mev-boost
 
-The minimum value could be lower than this and is highly dependent on your network topology.
-For example, if you are connected to peers who have gigabit connections, but you yourself have subpar bandwidth, it may be sufficient for you to only send your data to the first peer and in the time it takes you to send data to your mesh, the first peer might have seeded the network.
+- **Recommended**: 50 Mbps download / 25 Mbps upload.
+- **Rationale**:
+  - Most MEV-relay interactions involve fetching bundles and block headers, which can be done within typical broadband speeds.
+  - While the local validator will also share the block with its peers, the relay will do the same which reduces the need for local bandwidth.
+  - There may however be cases where your validator will still build a local block, such as if no mev-relay responds or if the value of the mev reward is lower than the minimum configuration set in mev-boost. In these circumstances, the recommendations for **Local Block Builders** would be relevant.
 
-The 25 Mbps was chosen as a buffer to account for these miscellaneous factors that are harder to predict.
+#### Full Nodes
 
-#### Validators using mev-boost
+- **Recommended**: 50 Mbps download / 15 Mbps upload.
+- **Rationale**:
+  - Full nodes currently participate in sampling and must track the chain tip, but are not as latency-sensitive as attesters or local block builders.
+  - They can operate on lower bandwidth but risk being a slot or more behind the chain if capacity is severely limited.
 
-The recommendation for validators using mev-boost is the same as the recommendations for attesters.
+## Quick Reference Summary
 
-#### Full nodes
+- **Full Node**  
+  - **Storage**: 4 TB NVMe  
+  - **RAM**: 32 GB  
+  - **CPU**: 4 cores / 8 threads (~1000 ST / ~3000 MT PassMark)  
+  - **Bandwidth**: 50 Mbps down / 15 Mbps up  
 
-For full nodes, whom want to follow the tip of the chain, we recommend 50 Mbps download and 15 Mbps upload.
+- **Attester**  
+  - **Storage**: 4 TB NVMe  
+  - **RAM**: 64 GB  
+  - **CPU**: 8 cores / 16 threads (~3500 ST / ~25000 MT PassMark)  
+  - **Bandwidth**: 50 Mbps down / 25 Mbps up  
 
-Full nodes currently participate in sampling, however since they are not latency sensitive like attesters and local block builders, we can lower their recommended upload bandwidth.
+- **Local Block Builder**  
+  - **Storage**: 4 TB NVMe  
+  - **RAM**: 64 GB  
+  - **CPU**: 8 cores / 16 threads (~3500 ST / ~25000 MT PassMark)  
+  - **Bandwidth**: 100 Mbps down / 50 Mbps up  
 
-The recommended download speed is kept the same, so that they are able to follow the chain at the same speed as an attester.
-
-Note: A full node will still be able to operate at significantly lower bandwidth, however depending on how low they may be at least a slot behind the chain.
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
Made various adjustments to make it a bit easier to read.

Included information about how even if you use mev-boost you may need the same bandwidth as a local block builder under certain conditions.

Included some additional details for choosing a NVMe drive

Added some information about what the PassMark CPU ratings translate into

Added a CPU section

Removed Statista as I don't believe it serves much of a purpose in the EIP other than providing some statistics as the existing numbers are not directly based on that but rather the existing requirements of the network itself, and I'm not sure how accurate the Statista numbers really are when looking at the median.

Added Quick Reference for those who just want the details
